### PR TITLE
PHP8 support added and cast to float in format method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4",
+        "php": "^7.4|^8.0",
         "ext-bcmath": "*"
     },
     "require-dev": {

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -20,7 +20,7 @@ abstract class Formatter
             NumberFormatter::MAX_FRACTION_DIGITS => $maxFractionDigits,
         ];
 
-        return self::get(NumberFormatter::DECIMAL, $locale, $options)->format($value);
+        return self::get(NumberFormatter::DECIMAL, $locale, $options)->format((float) $value);
     }
 
     /**


### PR DESCRIPTION
- PHP8 added in composer.json
- `(float)` cast added in `src/Formatter/Formatter.php ` `format` method

```
╰─ composer test
> vendor/bin/phpunit
PHPUnit 9.5.1 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.0.1
Configuration: /mnt/c/Users/fsociety/Code/php-number/phpunit.xml.dist
Warning:       No code coverage driver available

......................................................            54 / 54 (100%)

Time: 00:00.142, Memory: 6.00 MB

OK (54 tests, 155 assertions)
```