### PR TITLE
Add round, ceil, floor methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `php-number` will be documented in this file
 
+## 1.3.0
+- Added `round`, `ceil` & `floor` method in `AbstractNumber`
+- Improved unit tests when Intl extension is not loaded
+
 ## 1.2.0 - 2021-01-20
 - Added PHP 8 support + type fix ([#8](https://github.com/madebybob/php-number/pull/8) by [@affektde](https://github.com/affektde))
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ to the desired needs of your business.
     - [Multiply](#multiply)
     - [Modulus](#modulus)
     - [State & Comparison](#state--comparison)
+    - [Rounding](#rounding)
     - [Immutable & Chaining](#immutable--chaining)
     - [Extensibility](#extensibility)
 - [Testing](#testing--php-cs-fixer)
@@ -162,6 +163,22 @@ $number->isEqual('200');
 
 // check if the number is zero ("0")
 $number->isZero();
+```
+
+### Rounding
+To round the current number instance, the following methods are available:
+
+``` php
+$number = new Number('200.5000');
+
+// rounds the number to '201.0000'
+$number->round();
+
+// ceils the number to '201.0000'
+$number->ceil();
+
+// floors the number to '200.0000'
+$number->floor();
 ```
 
 ### Immutable & Chaining

--- a/src/AbstractNumber.php
+++ b/src/AbstractNumber.php
@@ -7,11 +7,23 @@ namespace Number;
 use Number\Exception\DecimalExponentError;
 use Number\Exception\DivisionByZeroError;
 use Number\Exception\InvalidNumberInputTypeException;
+use Number\Exception\InvalidRoundingModeException;
 
 abstract class AbstractNumber
 {
     protected const INTERNAL_SCALE = 12;
     protected const DEFAULT_SCALE = 4;
+
+    public const ROUND_HALF_UP = 1;
+    public const ROUND_HALF_DOWN = 2;
+    public const ROUND_HALF_EVEN = 3;
+    public const ROUND_HALF_ODD = 4;
+    private const ROUNDING_MODES = [
+        self::ROUND_HALF_UP => self::ROUND_HALF_UP,
+        self::ROUND_HALF_DOWN => self::ROUND_HALF_DOWN,
+        self::ROUND_HALF_EVEN => self::ROUND_HALF_EVEN,
+        self::ROUND_HALF_ODD => self::ROUND_HALF_ODD,
+    ];
 
     protected string $value;
     protected ?self $parent;
@@ -325,45 +337,30 @@ abstract class AbstractNumber
      * Rounds the current number, with a given precision (default 0).
      *
      * @param int $precision
-     * @return $this
      */
-    public function round(int $precision = 0): self
+    public function round(int $precision = 0, int $mode = self::ROUND_HALF_UP): self
     {
-        if ($this->isNegative()) {
-            return $this->subtract('0.' . str_repeat('0', $precision) . '5', $precision);
+        if (in_array($mode, self::ROUNDING_MODES) === false) {
+            throw new InvalidRoundingModeException();
         }
 
-        return $this->add('0.' . str_repeat('0', $precision) . '5', $precision);
+        return $this->init((string) round((float) $this->value, $precision, $mode));
     }
 
     /**
      * Ceils the current number.
-     *
-     * @return $this
      */
     public function ceil(): self
     {
-        $result = 1;
-        if (static::isNegative()) {
-            --$result;
-        }
-
-        return $this->add($result, 0);
+        return $this->init((string) ceil((float) $this->value));
     }
 
     /**
      * Floors the current number.
-     *
-     * @return $this
      */
     public function floor(): self
     {
-        $result = 0;
-        if (static::isNegative()) {
-            --$result;
-        }
-
-        return $this->add($result, 0);
+        return $this->init((string) floor((float) $this->value));
     }
 
     /**

--- a/src/AbstractNumber.php
+++ b/src/AbstractNumber.php
@@ -335,8 +335,6 @@ abstract class AbstractNumber
 
     /**
      * Rounds the current number, with a given precision (default 0).
-     *
-     * @param int $precision
      */
     public function round(int $precision = 0, int $mode = self::ROUND_HALF_UP): self
     {

--- a/src/AbstractNumber.php
+++ b/src/AbstractNumber.php
@@ -322,6 +322,51 @@ abstract class AbstractNumber
     }
 
     /**
+     * Rounds the current number, with a given precision (default 0).
+     *
+     * @param int $precision
+     * @return $this
+     */
+    public function round(int $precision = 0): self
+    {
+        if ($this->isNegative()) {
+            return $this->subtract('0.' . str_repeat('0', $precision) . '5', $precision);
+        }
+
+        return $this->add('0.' . str_repeat('0', $precision) . '5', $precision);
+    }
+
+    /**
+     * Ceils the current number.
+     *
+     * @return $this
+     */
+    public function ceil(): self
+    {
+        $result = 1;
+        if (static::isNegative()) {
+            --$result;
+        }
+
+        return $this->add($result, 0);
+    }
+
+    /**
+     * Floors the current number.
+     *
+     * @return $this
+     */
+    public function floor(): self
+    {
+        $result = 0;
+        if (static::isNegative()) {
+            --$result;
+        }
+
+        return $this->add($result, 0);
+    }
+
+    /**
      * Returns it's parent by which this instance was initialized.
      */
     public function parent(): ?self

--- a/src/Exception/InvalidRoundingModeException.php
+++ b/src/Exception/InvalidRoundingModeException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Number\Exception;
+
+use InvalidArgumentException;
+
+class InvalidRoundingModeException extends InvalidArgumentException
+{
+    public function __construct()
+    {
+        parent::__construct('Invalid rounding mode given.');
+    }
+}

--- a/tests/AbstractNumberImplementationTest.php
+++ b/tests/AbstractNumberImplementationTest.php
@@ -28,6 +28,12 @@ class AbstractNumberImplementationTest extends TestCase
 
     public function testFormatAbstractNumberImplementation(): void
     {
+        if (extension_loaded('intl') === false) {
+            $this->markTestSkipped('Intl extension not loaded.');
+
+            return;
+        }
+
         Locale::setDefault('nl_NL');
 
         $money = new Money('9342.1539');

--- a/tests/NumberTest.php
+++ b/tests/NumberTest.php
@@ -522,6 +522,48 @@ class NumberTest extends TestCase
         $this->assertFalse($five->isEqual('5.0001'));
     }
 
+    public function testRound(): void
+    {
+        $number = new Number('4.9000');
+        $this->assertEquals('5', $number->round(0));
+
+        $number = new Number('4.1000');
+        $this->assertEquals('4', $number->round(0));
+
+        $number = new Number('4.4900');
+        $this->assertEquals('4', $number->round(0));
+
+        $number = new Number('4.5000');
+        $this->assertEquals('5', $number->round(0));
+
+        $number = new Number('4.5100');
+        $this->assertEquals('5', $number->round(0));
+
+        $number = new Number('4.4720');
+        $this->assertEquals('4.4700', $number->round(2));
+
+        $number = new Number('4.4770');
+        $this->assertEquals('4.4800', $number->round(2));
+
+        // $number = new Number('4200.0000');
+        // $this->assertEquals('4000.0000', $number->round(-3));
+
+    }
+
+    public function testCeil(): void
+    {
+        $number = new Number('4.1000');
+
+        $this->assertEquals('5.0000', $number->ceil()->toString());
+    }
+
+    public function testFloor(): void
+    {
+        $number = new Number('4.9000');
+
+        $this->assertEquals('4.0000', $number->floor()->toString());
+    }
+
     public function testCanTraceByParent(): void
     {
         $five = new Number(5);

--- a/tests/NumberTest.php
+++ b/tests/NumberTest.php
@@ -524,50 +524,53 @@ class NumberTest extends TestCase
 
     public function testRound(): void
     {
-        $number = new Number('4.9000');
-        $this->assertEquals('5', $number->round(0));
+        $this->assertEquals('5.0000', Number::create('4.900')->round(0)->toString());
+        $this->assertEquals('4.0000', Number::create('4.1000')->round(0)->toString());
+        $this->assertEquals('4.0000', Number::create('4.4900')->round(0)->toString());
+        $this->assertEquals('5.0000', Number::create('4.5000')->round(0)->toString());
+        $this->assertEquals('5.0000', Number::create('4.5100')->round(0)->toString());
 
-        $number = new Number('4.1000');
-        $this->assertEquals('4', $number->round(0));
+        $this->assertEquals('4.4700', Number::create('4.4720')->round(2)->toString());
+        $this->assertEquals('4.4800', Number::create('4.4770')->round(2)->toString());
 
-        $number = new Number('4.4900');
-        $this->assertEquals('4', $number->round(0));
+        $this->assertEquals('8.4780', Number::create('8.4776')->round(3)->toString());
+        $this->assertEquals('8.4770', Number::create('8.4772')->round(3)->toString());
 
-        $number = new Number('4.5000');
-        $this->assertEquals('5', $number->round(0));
+        $this->assertEquals('4000.0000', Number::create('4200.0000')->round(-3)->toString());
+        $this->assertEquals('50000.0000', Number::create('46000.0000')->round(-4)->toString());
 
-        $number = new Number('4.5100');
-        $this->assertEquals('5', $number->round(0));
+        $this->assertEquals('-5.0000', Number::create('-4.900')->round(0)->toString());
+        $this->assertEquals('-4.0000', Number::create('-4.1000')->round(0)->toString());
+        $this->assertEquals('-4.0000', Number::create('-4.4900')->round(0)->toString());
+        $this->assertEquals('-5.0000', Number::create('-4.5000')->round(0)->toString());
+        $this->assertEquals('-5.0000', Number::create('-4.5100')->round(0)->toString());
 
-        $number = new Number('4.4720');
-        $this->assertEquals('4.4700', $number->round(2));
+        $this->assertEquals('-4.4700', Number::create('-4.4720')->round(2)->toString());
+        $this->assertEquals('-4.4800', Number::create('-4.4770')->round(2)->toString());
 
-        $number = new Number('4.4770');
-        $this->assertEquals('4.4800', $number->round(2));
+        $this->assertEquals('-8.4780', Number::create('-8.4776')->round(3)->toString());
+        $this->assertEquals('-8.4770', Number::create('-8.4772')->round(3)->toString());
 
-        $number = new Number('4200.0000');
-        $this->assertEquals('4000.0000', $number->round(-3));
-
-        $number = new Number('46000.0000');
-        $this->assertEquals('50000.0000', $number->round(-4));
+        $this->assertEquals('-4000.0000', Number::create('-4200.0000')->round(-3)->toString());
+        $this->assertEquals('-50000.0000', Number::create('-46000.0000')->round(-4)->toString());
     }
 
     public function testCeil(): void
     {
-        $number = new Number('4.1000');
-        $this->assertEquals('5.0000', $number->ceil()->toString());
+        $this->assertEquals('5.0000', Number::create('4.1000')->ceil()->toString());
+        $this->assertEquals('5.0000', Number::create('4.8000')->ceil()->toString());
 
-        $number = new Number('-4.1000');
-        $this->assertEquals('-4.0000', $number->ceil()->toString());
+        $this->assertEquals('-4.0000', Number::create('-4.1000')->ceil()->toString());
+        $this->assertEquals('-4.0000', Number::create('-4.8000')->ceil()->toString());
     }
 
     public function testFloor(): void
     {
-        $number = new Number('4.9000');
-        $this->assertEquals('4.0000', $number->floor()->toString());
+        $this->assertEquals('4.0000', Number::create('4.9000')->floor()->toString());
+        $this->assertEquals('4.0000', Number::create('4.1000')->floor()->toString());
 
-        $number = new Number('-4.9000');
-        $this->assertEquals('-5.0000', $number->floor()->toString());
+        $this->assertEquals('-5.0000', Number::create('-4.9000')->floor()->toString());
+        $this->assertEquals('-5.0000', Number::create('-4.1000')->floor()->toString());
     }
 
     public function testCanTraceByParent(): void

--- a/tests/NumberTest.php
+++ b/tests/NumberTest.php
@@ -547,7 +547,6 @@ class NumberTest extends TestCase
 
         // $number = new Number('4200.0000');
         // $this->assertEquals('4000.0000', $number->round(-3));
-
     }
 
     public function testCeil(): void

--- a/tests/NumberTest.php
+++ b/tests/NumberTest.php
@@ -588,6 +588,12 @@ class NumberTest extends TestCase
 
     public function testFormatNumber(): void
     {
+        if (extension_loaded('intl') === false) {
+            $this->markTestSkipped('Intl extension not loaded.');
+
+            return;
+        }
+
         Locale::setDefault('nl_NL');
 
         // Round up, default 4 fraction digits

--- a/tests/NumberTest.php
+++ b/tests/NumberTest.php
@@ -545,22 +545,29 @@ class NumberTest extends TestCase
         $number = new Number('4.4770');
         $this->assertEquals('4.4800', $number->round(2));
 
-        // $number = new Number('4200.0000');
-        // $this->assertEquals('4000.0000', $number->round(-3));
+        $number = new Number('4200.0000');
+        $this->assertEquals('4000.0000', $number->round(-3));
+
+        $number = new Number('46000.0000');
+        $this->assertEquals('50000.0000', $number->round(-4));
     }
 
     public function testCeil(): void
     {
         $number = new Number('4.1000');
-
         $this->assertEquals('5.0000', $number->ceil()->toString());
+
+        $number = new Number('-4.1000');
+        $this->assertEquals('-4.0000', $number->ceil()->toString());
     }
 
     public function testFloor(): void
     {
         $number = new Number('4.9000');
-
         $this->assertEquals('4.0000', $number->floor()->toString());
+
+        $number = new Number('-4.9000');
+        $this->assertEquals('-5.0000', $number->floor()->toString());
     }
 
     public function testCanTraceByParent(): void


### PR DESCRIPTION
This PR implements the following rounding methods:
- round
- ceil
- floor

One limitation is round on hundreds or thousands (example here: https://stackoverflow.com/questions/5150001/how-to-round-to-nearest-thousand).

For example: `33255` rounded on thousands should return `33000`. 

This needs to be added before merging.