### PR TITLE
Absolute method + Opposite method

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ to the desired needs of your business.
     - [Multiply](#multiply)
     - [Modulus](#modulus)
     - [State & Comparison](#state--comparison)
+    - [Absolute values](#absolute-values)
     - [Rounding](#rounding)
     - [Immutable & Chaining](#immutable--chaining)
     - [Extensibility](#extensibility)
@@ -163,6 +164,19 @@ $number->isEqual('200');
 
 // check if the number is zero ("0")
 $number->isZero();
+```
+
+### Absolute values
+To get the absolute (positive) value of the current instance:
+
+``` php
+$number = new Number('-200');
+
+// $absolute will be 200
+$absolute = $number->absolute();
+
+// abs is an alias for absolute
+$abs = $number->abs();
 ```
 
 ### Rounding

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ to the desired needs of your business.
     - [Multiply](#multiply)
     - [Modulus](#modulus)
     - [State & Comparison](#state--comparison)
-    - [Absolute values](#absolute-values)
+    - [Absolute & opposite values](#absolute--opposite-values)
     - [Rounding](#rounding)
     - [Immutable & Chaining](#immutable--chaining)
     - [Extensibility](#extensibility)
@@ -166,7 +166,7 @@ $number->isEqual('200');
 $number->isZero();
 ```
 
-### Absolute values
+### Absolute & opposite values
 To get the absolute (positive) value of the current instance:
 
 ``` php
@@ -177,6 +177,18 @@ $absolute = $number->absolute();
 
 // abs is an alias for absolute
 $abs = $number->abs();
+```
+
+To get the opposite value of the current instance:
+
+``` php
+$number = new Number('200');
+
+// $absolute will be -200
+$absolute = $number->opposite();
+
+// opp is an alias for absolute
+$abs = $number->opp();
 ```
 
 ### Rounding

--- a/src/AbstractNumber.php
+++ b/src/AbstractNumber.php
@@ -263,11 +263,31 @@ abstract class AbstractNumber
     }
 
     /**
+     * Get the absolute value of the current value.
+     */
+    public function absolute(): self
+    {
+        if ($this->isPositive()) {
+            return $this;
+        }
+
+        return $this->multiply(-1);
+    }
+
+    /**
+     * Alias for absolute method.
+     */
+    public function abs(): self
+    {
+        return $this->absolute();
+    }
+
+    /**
      * Return boolean if the current value is a positive number.
      */
     public function isPositive(): bool
     {
-        return bccomp($this->value, '0') === 1;
+        return bccomp($this->value, '0', self::INTERNAL_SCALE) === 1;
     }
 
     /**
@@ -275,7 +295,7 @@ abstract class AbstractNumber
      */
     public function isNegative(): bool
     {
-        return bccomp($this->value, '0') === -1;
+        return bccomp($this->value, '0', self::INTERNAL_SCALE) === -1;
     }
 
     /**

--- a/src/AbstractNumber.php
+++ b/src/AbstractNumber.php
@@ -283,6 +283,22 @@ abstract class AbstractNumber
     }
 
     /**
+     * Get the opposite value of the current value.
+     */
+    public function opposite(): self
+    {
+        return $this->multiply(-1);
+    }
+
+    /**
+     * Alias for opposite method.
+     */
+    public function opp(): self
+    {
+        return $this->opposite();
+    }
+
+    /**
      * Return boolean if the current value is a positive number.
      */
     public function isPositive(): bool

--- a/tests/NumberTest.php
+++ b/tests/NumberTest.php
@@ -458,10 +458,26 @@ class NumberTest extends TestCase
         $this->assertEquals('14', $number->sqrt(0));
     }
 
+    public function testAbsolute()
+    {
+        $this->assertEquals('0.0000', Number::create('-0')->absolute()->toString());
+        $this->assertEquals('0.0000', Number::create('0')->absolute()->toString());
+
+        $this->assertEquals('14.0000', Number::create('-14.0000')->absolute()->toString());
+        $this->assertEquals('14.0000', Number::create('14.0000')->absolute()->toString());
+
+        $this->assertEquals('20.0000', Number::create('-20')->absolute()->toString());
+        $this->assertEquals('20.0000', Number::create('20')->absolute()->toString());
+
+        $this->assertEquals('0.3000', Number::create('-0.3000')->absolute()->toString());
+        $this->assertEquals('0.3000', Number::create('0.3000')->absolute()->toString());
+    }
+
     public function testIsPositive(): void
     {
         $this->assertTrue((new Number('200'))->isPositive());
         $this->assertTrue((new Number('1'))->isPositive());
+        $this->assertTrue((new Number('0.3000'))->isPositive());
 
         $this->assertFalse((new Number('200'))->isNegative());
         $this->assertFalse((new Number('1'))->isNegative());

--- a/tests/NumberTest.php
+++ b/tests/NumberTest.php
@@ -473,6 +473,21 @@ class NumberTest extends TestCase
         $this->assertEquals('0.3000', Number::create('0.3000')->absolute()->toString());
     }
 
+    public function testOpposite()
+    {
+        $this->assertEquals('0.0000', Number::create('-0')->opposite()->toString());
+        $this->assertEquals('0.0000', Number::create('0')->opposite()->toString());
+
+        $this->assertEquals('14.0000', Number::create('-14.0000')->opposite()->toString());
+        $this->assertEquals('-14.0000', Number::create('14.0000')->opposite()->toString());
+
+        $this->assertEquals('20.0000', Number::create('-20')->opposite()->toString());
+        $this->assertEquals('-20.0000', Number::create('20')->opposite()->toString());
+
+        $this->assertEquals('0.3000', Number::create('-0.3000')->opposite()->toString());
+        $this->assertEquals('-0.3000', Number::create('0.3000')->opposite()->toString());
+    }
+
     public function testIsPositive(): void
     {
         $this->assertTrue((new Number('200'))->isPositive());


### PR DESCRIPTION
This PR implements the `absolute` and `abs` method to get an... Yeah... Absolute value ;)

Also, I've fixed a small nasty bug. Calling `isPositive()` on a value between 0 and 1, like `0.3000`, resulted into `false`. This is fixed now, by adding the internal scale to the used `bccomp` value.